### PR TITLE
bug fix day4

### DIFF
--- a/day04/harib01f/bootpack.c
+++ b/day04/harib01f/bootpack.c
@@ -12,6 +12,10 @@ void set_palette(int start, int end, unsigned char *rgb);
 void HariMain(void)
 {
   char *p;  // BYTE [...]用番地
+
+  init_palette();
+
+
   p = (char *) 0xa0000;
 
   for (int i=0; i <= 0xffff; i++){


### PR DESCRIPTION
haribo01fにおいて実行しても画面の色がharibo01eから変わらないというバグがありました。
bootpack.cのHariMain内にてinit_paletteが実行されていないことが問題だったため、この一行を追加しました。